### PR TITLE
Add --since scoping to spec.next and spec.prime

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ For bug fixes:
 mix spec.next --bugfix
 ```
 
+For one focused workset inside a longer-lived branch:
+
+```bash
+mix spec.next --base main --since <checkpoint>
+```
+
 ## Local Usage
 
 Add as a path dependency in another project:

--- a/lib/mix/tasks/spec.next.ex
+++ b/lib/mix/tasks/spec.next.ex
@@ -10,7 +10,13 @@ defmodule Mix.Tasks.Spec.Next do
     {opts, rest, invalid} =
       OptionParser.parse(
         args,
-        strict: [root: :string, spec_dir: :string, base: :string, bugfix: :boolean],
+        strict: [
+          root: :string,
+          spec_dir: :string,
+          base: :string,
+          since: :string,
+          bugfix: :boolean
+        ],
         aliases: [r: :root]
       )
 
@@ -20,7 +26,9 @@ defmodule Mix.Tasks.Spec.Next do
     spec_dir = opts[:spec_dir] || SpecLedEx.detect_spec_dir(root)
     authored_dir = SpecLedEx.detect_authored_dir(root, spec_dir)
     index = SpecLedEx.index(root, spec_dir: spec_dir, authored_dir: authored_dir)
-    report = SpecLedEx.next(index, root, base: opts[:base], bugfix: opts[:bugfix])
+
+    report =
+      SpecLedEx.next(index, root, base: opts[:base], since: opts[:since], bugfix: opts[:bugfix])
 
     Mix.shell().info(SpecLedEx.Next.format_human(report))
   end

--- a/lib/mix/tasks/spec.prime.ex
+++ b/lib/mix/tasks/spec.prime.ex
@@ -24,6 +24,7 @@ defmodule Mix.Tasks.Spec.Prime do
           root: :string,
           spec_dir: :string,
           base: :string,
+          since: :string,
           bugfix: :boolean,
           run_commands: :boolean,
           min_strength: :string,
@@ -48,6 +49,7 @@ defmodule Mix.Tasks.Spec.Prime do
     report =
       SpecLedEx.prime(index, verification_report, root,
         base: opts[:base],
+        since: opts[:since],
         bugfix: opts[:bugfix],
         run_commands: run_commands?(opts)
       )

--- a/lib/specled_ex/change_analysis.ex
+++ b/lib/specled_ex/change_analysis.ex
@@ -10,7 +10,9 @@ defmodule SpecLedEx.ChangeAnalysis do
   def analyze(index, root, opts \\ []) do
     git_repo? = git_repo?(root)
     base = detect_base_ref(root, opts[:base], git_repo?)
-    changed_files = changed_files(root, base, git_repo?)
+    since = detect_since_ref(root, opts[:since], git_repo?)
+    guidance_scope = guidance_scope(base, since)
+    changed_files = changed_files(root, guidance_scope, git_repo?)
     subject_file_map = Coverage.subject_file_map(index, root)
     changed_subject_ids = changed_subject_ids(index, changed_files)
     policy_files = Enum.filter(changed_files, &policy_target?/1)
@@ -36,6 +38,8 @@ defmodule SpecLedEx.ChangeAnalysis do
     %{
       git_repo?: git_repo?,
       base: base,
+      since: since,
+      guidance_scope: guidance_scope,
       changed_files: changed_files,
       policy_files: policy_files,
       subject_file_map: subject_file_map,
@@ -72,14 +76,14 @@ defmodule SpecLedEx.ChangeAnalysis do
   def changed_files(root, explicit_base \\ nil) do
     git_repo? = git_repo?(root)
     base = detect_base_ref(root, explicit_base, git_repo?)
-    changed_files(root, base, git_repo?)
+    changed_files(root, guidance_scope(base, nil), git_repo?)
   end
 
-  defp changed_files(_root, _base, false), do: []
+  defp changed_files(_root, _scope, false), do: []
 
-  defp changed_files(root, base, true) do
+  defp changed_files(root, scope, true) do
     [
-      diff_against_base(root, base),
+      scope_diff(root, scope),
       working_tree_diff(root),
       staged_diff(root),
       untracked_files(root)
@@ -95,6 +99,10 @@ defmodule SpecLedEx.ChangeAnalysis do
     detect_base_ref(root, explicit_base, git_repo?(root))
   end
 
+  def detect_since_ref(root, explicit_since \\ nil) do
+    detect_since_ref(root, explicit_since, git_repo?(root))
+  end
+
   defp detect_base_ref(_root, explicit_base, _git_repo?) when is_binary(explicit_base),
     do: explicit_base
 
@@ -102,6 +110,19 @@ defmodule SpecLedEx.ChangeAnalysis do
 
   defp detect_base_ref(root, nil, true) do
     Enum.find(["origin/main", "main", "master", "HEAD"], &git_ref_exists?(root, &1)) || "HEAD"
+  end
+
+  defp detect_since_ref(_root, nil, _git_repo?), do: nil
+
+  defp detect_since_ref(_root, explicit_since, false) when is_binary(explicit_since),
+    do: explicit_since
+
+  defp detect_since_ref(root, explicit_since, true) when is_binary(explicit_since) do
+    if git_ref_exists?(root, explicit_since) do
+      explicit_since
+    else
+      raise "git ref not found for --since: #{explicit_since}"
+    end
   end
 
   def decision_file?(path) do
@@ -144,6 +165,10 @@ defmodule SpecLedEx.ChangeAnalysis do
     git_lines(root, ["diff", "--name-only", "#{base}...HEAD"])
   end
 
+  defp diff_since_ref(root, since) do
+    git_lines(root, ["diff", "--name-only", "#{since}..HEAD"])
+  end
+
   defp working_tree_diff(root) do
     git_lines(root, ["diff", "--name-only"])
   end
@@ -183,6 +208,12 @@ defmodule SpecLedEx.ChangeAnalysis do
   end
 
   defp generated_state_file?(path), do: path == ".spec/state.json"
+
+  defp guidance_scope(_base, since) when is_binary(since), do: %{type: :since, ref: since}
+  defp guidance_scope(base, _since), do: %{type: :branch, ref: base}
+
+  defp scope_diff(root, %{type: :since, ref: since}), do: diff_since_ref(root, since)
+  defp scope_diff(root, %{type: :branch, ref: base}), do: diff_against_base(root, base)
 
   defp subject_file(subject) when is_map(subject) do
     Map.get(subject, "file", Map.get(subject, :file))

--- a/lib/specled_ex/next.ex
+++ b/lib/specled_ex/next.ex
@@ -12,7 +12,10 @@ defmodule SpecLedEx.Next do
 
     %{
       "base" => analysis.base,
+      "since" => analysis.since,
       "bugfix" => Keyword.get(opts, :bugfix, false),
+      "guidance_scope" => guidance_scope_label(analysis),
+      "check_scope" => check_scope_label(analysis),
       "changed_files" => analysis.changed_files,
       "policy_files" => analysis.policy_files,
       "classification" => classification,
@@ -34,6 +37,7 @@ defmodule SpecLedEx.Next do
       [
         "Spec Led Next",
         "base=#{report["base"]} changed_files=#{length(report["changed_files"] || [])} policy_files=#{length(report["policy_files"] || [])}",
+        "guidance_scope=#{report["guidance_scope"]} check_scope=#{report["check_scope"]}",
         "classification=#{report["classification_label"]}",
         "reconciliation=#{report["reconciliation_label"]}",
         "rationale=#{report["rationale"]}"
@@ -314,4 +318,11 @@ defmodule SpecLedEx.Next do
 
   defp check_command(%{git_repo?: true, base: base}), do: "mix spec.check --base #{base}"
   defp check_command(_analysis), do: "mix spec.check"
+
+  defp guidance_scope_label(%{since: since}) when is_binary(since), do: "since #{since}"
+  defp guidance_scope_label(%{git_repo?: true, base: base}), do: "branch vs #{base}"
+  defp guidance_scope_label(_analysis), do: "workspace"
+
+  defp check_scope_label(%{git_repo?: true, base: base}), do: "full branch vs #{base}"
+  defp check_scope_label(_analysis), do: "workspace"
 end

--- a/lib/specled_ex/prime.ex
+++ b/lib/specled_ex/prime.ex
@@ -7,7 +7,7 @@ defmodule SpecLedEx.Prime do
     run_commands? = opts[:run_commands] == true
     bugfix? = opts[:bugfix] == true
     status_report = Status.build(index, verification_report, root)
-    next_report = Next.run(index, root, base: opts[:base], bugfix: bugfix?)
+    next_report = Next.run(index, root, base: opts[:base], since: opts[:since], bugfix: bugfix?)
 
     %{
       "generated_at" => status_report["generated_at"],

--- a/test/mix/tasks/spec_next_task_test.exs
+++ b/test/mix/tasks/spec_next_task_test.exs
@@ -154,6 +154,69 @@ defmodule Mix.Tasks.SpecNextTaskTest do
     assert message_contains?(messages, "mix spec.check --base HEAD")
   end
 
+  test "spec.next --since scopes guidance to changes after a checkpoint", %{root: root} do
+    init_git_repo(root)
+
+    write_files(root, %{
+      "lib/a.ex" => "defmodule A do\nend\n",
+      "lib/b.ex" => "defmodule B do\nend\n"
+    })
+
+    write_subject_spec(
+      root,
+      "a",
+      meta: %{
+        "id" => "a.subject",
+        "kind" => "module",
+        "status" => "active",
+        "surface" => ["lib/a.ex"]
+      }
+    )
+
+    write_subject_spec(
+      root,
+      "b",
+      meta: %{
+        "id" => "b.subject",
+        "kind" => "module",
+        "status" => "active",
+        "surface" => ["lib/b.ex"]
+      }
+    )
+
+    commit_all(root, "initial")
+    git!(root, ["checkout", "-b", "feature/workset"])
+
+    write_files(root, %{
+      "lib/a.ex" => "defmodule A do\n  def run, do: :ok\nend\n"
+    })
+
+    File.write!(
+      Path.join(root, ".spec/specs/a.spec.md"),
+      File.read!(Path.join(root, ".spec/specs/a.spec.md")) <> "\n"
+    )
+
+    commit_all(root, "complete first ticket")
+    checkpoint = root |> git!(["rev-parse", "HEAD"]) |> String.trim()
+
+    write_files(root, %{
+      "lib/b.ex" => "defmodule B do\n  def run, do: :ok\nend\n"
+    })
+
+    commit_all(root, "start second ticket")
+
+    Mix.Tasks.Spec.Next.run(["--root", root, "--base", "main", "--since", checkpoint])
+    messages = drain_shell_messages()
+
+    assert message_contains?(messages, "guidance_scope=since #{checkpoint}")
+    assert message_contains?(messages, "check_scope=full branch vs main")
+    assert message_contains?(messages, "classification=covered local change")
+    assert message_contains?(messages, "reconciliation=needs subject updates")
+    assert message_contains?(messages, "b.subject (.spec/specs/b.spec.md)")
+    refute message_contains?(messages, "a.subject (.spec/specs/a.spec.md)")
+    assert message_contains?(messages, "mix spec.check --base main")
+  end
+
   test "spec.next says ready for check when current truth and ADR updates are already present", %{
     root: root
   } do

--- a/test/mix/tasks/spec_prime_task_test.exs
+++ b/test/mix/tasks/spec_prime_task_test.exs
@@ -80,6 +80,8 @@ defmodule Mix.Tasks.SpecPrimeTaskTest do
       root,
       "--base",
       "HEAD",
+      "--since",
+      "HEAD",
       "--bugfix",
       "--run-commands",
       "--json"
@@ -92,7 +94,9 @@ defmodule Mix.Tasks.SpecPrimeTaskTest do
     assert report["summary"]["run_commands"] == true
     assert report["summary"]["bugfix"] == true
     assert report["next"]["base"] == "HEAD"
+    assert report["next"]["since"] == "HEAD"
     assert report["next"]["bugfix"] == true
+    assert report["next"]["guidance_scope"] == "since HEAD"
     assert report["next"]["classification"] == "covered_local_change"
     assert report["next"]["reconciliation"] == "needs_subject_updates"
 


### PR DESCRIPTION
## Summary
- add `--since <ref>` support to `mix spec.next` and `mix spec.prime`
- scope change analysis to files changed since a checkpoint without changing `mix spec.check` semantics
- surface guidance scope vs check scope in output and document the focused workset flow

## Testing
- mix test test/mix/tasks/spec_next_task_test.exs test/mix/tasks/spec_prime_task_test.exs
- mix test

Part of #3.