### PR TITLE
Make spec.next compact by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ For one focused workset inside a longer-lived branch:
 mix spec.next --base main --since <checkpoint>
 ```
 
+Add `--verbose` when you want the raw changed-file lists in the guidance output.
+
 ## Local Usage
 
 Add as a path dependency in another project:

--- a/lib/mix/tasks/spec.next.ex
+++ b/lib/mix/tasks/spec.next.ex
@@ -15,6 +15,7 @@ defmodule Mix.Tasks.Spec.Next do
           spec_dir: :string,
           base: :string,
           since: :string,
+          verbose: :boolean,
           bugfix: :boolean
         ],
         aliases: [r: :root]
@@ -30,7 +31,7 @@ defmodule Mix.Tasks.Spec.Next do
     report =
       SpecLedEx.next(index, root, base: opts[:base], since: opts[:since], bugfix: opts[:bugfix])
 
-    Mix.shell().info(SpecLedEx.Next.format_human(report))
+    Mix.shell().info(SpecLedEx.Next.format_human(report, verbose: opts[:verbose] || false))
   end
 
   defp validate_args!([], []), do: :ok

--- a/lib/specled_ex/next.ex
+++ b/lib/specled_ex/next.ex
@@ -32,7 +32,9 @@ defmodule SpecLedEx.Next do
     }
   end
 
-  def format_human(report) do
+  def format_human(report, opts \\ []) do
+    verbose? = Keyword.get(opts, :verbose, false)
+
     lines =
       [
         "Spec Led Next",
@@ -42,9 +44,14 @@ defmodule SpecLedEx.Next do
         "reconciliation=#{report["reconciliation_label"]}",
         "rationale=#{report["rationale"]}"
       ] ++
-        format_items("changed_files", report["changed_files"] || []) ++
+        format_verbose_items(verbose?, "changed_files", report["changed_files"] || []) ++
+        format_verbose_items(verbose?, "policy_files", report["policy_files"] || []) ++
         format_subjects(report["subject_refs"] || []) ++
-        format_items("uncovered_policy_files", report["uncovered_policy_files"] || []) ++
+        format_optional_items(
+          verbose? or report["uncovered_policy_files"] != [],
+          "uncovered_policy_files",
+          report["uncovered_policy_files"] || []
+        ) ++
         format_items("next_steps", report["next_steps"] || []) ++
         format_items("commands", report["suggested_commands"] || [])
 
@@ -296,6 +303,12 @@ defmodule SpecLedEx.Next do
   defp format_items(label, items) do
     ["#{label}:"] ++ Enum.map(items, &"- #{&1}")
   end
+
+  defp format_optional_items(false, _label, _items), do: []
+  defp format_optional_items(true, label, items), do: format_items(label, items)
+
+  defp format_verbose_items(false, _label, _items), do: []
+  defp format_verbose_items(true, label, items), do: format_items(label, items)
 
   defp format_subjects([]), do: ["impacted_subjects=none"]
 

--- a/test/mix/tasks/spec_next_task_test.exs
+++ b/test/mix/tasks/spec_next_task_test.exs
@@ -217,6 +217,49 @@ defmodule Mix.Tasks.SpecNextTaskTest do
     assert message_contains?(messages, "mix spec.check --base main")
   end
 
+  test "spec.next keeps default output compact and expands file lists with --verbose", %{
+    root: root
+  } do
+    init_git_repo(root)
+
+    write_files(root, %{
+      "lib/example.ex" => "defmodule Example do\nend\n"
+    })
+
+    write_subject_spec(
+      root,
+      "example",
+      meta: %{
+        "id" => "example.subject",
+        "kind" => "module",
+        "status" => "active",
+        "surface" => ["lib/example.ex"]
+      }
+    )
+
+    commit_all(root, "initial")
+
+    write_files(root, %{
+      "lib/example.ex" => "defmodule Example do\n  def run, do: :ok\nend\n"
+    })
+
+    Mix.Tasks.Spec.Next.run(["--root", root, "--base", "HEAD"])
+    compact_messages = drain_shell_messages()
+
+    assert message_contains?(compact_messages, "classification=covered local change")
+    refute message_contains?(compact_messages, "changed_files:")
+    refute message_contains?(compact_messages, "policy_files:")
+
+    reenable_tasks(["spec.next"])
+
+    Mix.Tasks.Spec.Next.run(["--root", root, "--base", "HEAD", "--verbose"])
+    verbose_messages = drain_shell_messages()
+
+    assert message_contains?(verbose_messages, "changed_files:")
+    assert message_contains?(verbose_messages, "- lib/example.ex")
+    assert message_contains?(verbose_messages, "policy_files:")
+  end
+
   test "spec.next says ready for check when current truth and ADR updates are already present", %{
     root: root
   } do


### PR DESCRIPTION
## Summary
- keep `mix spec.next` focused on the key guidance by default
- add `--verbose` for raw changed-file and policy-file lists
- document the verbose escape hatch for longer worksets

## Testing
- mix test test/mix/tasks/spec_next_task_test.exs
- mix test

Stacked on #4.
Part of #3.