### PR TITLE
Add JSON output to spec.next

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ mix spec.next --base main --since <checkpoint>
 ```
 
 Add `--verbose` when you want the raw changed-file lists in the guidance output.
+Add `--json` when an editor, script, or agent needs the structured report.
 
 ## Local Usage
 

--- a/lib/mix/tasks/spec.next.ex
+++ b/lib/mix/tasks/spec.next.ex
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.Spec.Next do
           base: :string,
           since: :string,
           verbose: :boolean,
+          json: :boolean,
           bugfix: :boolean
         ],
         aliases: [r: :root]
@@ -31,7 +32,11 @@ defmodule Mix.Tasks.Spec.Next do
     report =
       SpecLedEx.next(index, root, base: opts[:base], since: opts[:since], bugfix: opts[:bugfix])
 
-    Mix.shell().info(SpecLedEx.Next.format_human(report, verbose: opts[:verbose] || false))
+    if opts[:json] do
+      Mix.shell().info(Jason.encode!(report, pretty: true))
+    else
+      Mix.shell().info(SpecLedEx.Next.format_human(report, verbose: opts[:verbose] || false))
+    end
   end
 
   defp validate_args!([], []), do: :ok

--- a/test/mix/tasks/spec_next_task_test.exs
+++ b/test/mix/tasks/spec_next_task_test.exs
@@ -260,6 +260,46 @@ defmodule Mix.Tasks.SpecNextTaskTest do
     assert message_contains?(verbose_messages, "policy_files:")
   end
 
+  test "spec.next supports json output", %{root: root} do
+    init_git_repo(root)
+
+    write_files(root, %{
+      "lib/example.ex" => "defmodule Example do\nend\n"
+    })
+
+    write_subject_spec(
+      root,
+      "example",
+      meta: %{
+        "id" => "example.subject",
+        "kind" => "module",
+        "status" => "active",
+        "surface" => ["lib/example.ex"]
+      }
+    )
+
+    commit_all(root, "initial")
+
+    write_files(root, %{
+      "lib/example.ex" => "defmodule Example do\n  def run, do: :ok\nend\n"
+    })
+
+    Mix.Tasks.Spec.Next.run(["--root", root, "--base", "HEAD", "--since", "HEAD", "--json"])
+    [json] = drain_shell_messages()
+    report = Jason.decode!(json)
+
+    assert report["base"] == "HEAD"
+    assert report["since"] == "HEAD"
+    assert report["guidance_scope"] == "since HEAD"
+    assert report["classification"] == "covered_local_change"
+    assert report["reconciliation"] == "needs_subject_updates"
+    assert report["changed_files"] == ["lib/example.ex"]
+
+    assert report["subject_refs"] == [
+             %{"file" => ".spec/specs/example.spec.md", "id" => "example.subject"}
+           ]
+  end
+
   test "spec.next says ready for check when current truth and ADR updates are already present", %{
     root: root
   } do


### PR DESCRIPTION
## Summary
- add `--json` to `mix spec.next`
- emit the existing structured next report for editors, scripts, and agent tooling
- cover the new flag with a task-level regression test and README note

## Testing
- mix test test/mix/tasks/spec_next_task_test.exs
- mix test

Stacked on #5.
Part of #3.