### PR TITLE
[codex] Use loadpaths for Spec Led Mix tasks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Hostetler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/mix/tasks/spec.check.ex
+++ b/lib/mix/tasks/spec.check.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Spec.Check do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   alias SpecLedEx.VerificationStrength
 
@@ -19,8 +20,6 @@ defmodule Mix.Tasks.Spec.Check do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.decision.new.ex
+++ b/lib/mix/tasks/spec.decision.new.ex
@@ -1,13 +1,12 @@
 defmodule Mix.Tasks.Spec.Decision.New do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   @shortdoc "Scaffolds a decision ADR under .spec/decisions"
   @id_pattern ~r/^[a-z0-9][a-z0-9._-]*$/
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.index.ex
+++ b/lib/mix/tasks/spec.index.ex
@@ -1,12 +1,11 @@
 defmodule Mix.Tasks.Spec.Index do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   @shortdoc "Builds index state and writes .spec/state.json"
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.init.ex
+++ b/lib/mix/tasks/spec.init.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Spec.Init do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   @shortdoc "Scaffolds a canonical .spec/ workspace"
   @templates [
@@ -17,8 +18,6 @@ defmodule Mix.Tasks.Spec.Init do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(args,
         strict: [root: :string, force: :boolean],

--- a/lib/mix/tasks/spec.next.ex
+++ b/lib/mix/tasks/spec.next.ex
@@ -1,12 +1,11 @@
 defmodule Mix.Tasks.Spec.Next do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   @shortdoc "Guides the next current-truth update for the current Git change set"
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.prime.ex
+++ b/lib/mix/tasks/spec.prime.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Spec.Prime do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   alias SpecLedEx.VerificationStrength
 
@@ -15,8 +16,6 @@ defmodule Mix.Tasks.Spec.Prime do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.status.ex
+++ b/lib/mix/tasks/spec.status.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Spec.Status do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   alias SpecLedEx.VerificationStrength
 
@@ -14,8 +15,6 @@ defmodule Mix.Tasks.Spec.Status do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.validate.ex
+++ b/lib/mix/tasks/spec.validate.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Spec.Validate do
   use Mix.Task
+  @requirements ["loadpaths"]
 
   alias SpecLedEx.VerificationStrength
 
@@ -16,8 +17,6 @@ defmodule Mix.Tasks.Spec.Validate do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,


### PR DESCRIPTION
## Summary

This changes the `specled_ex` Mix tasks to use `@requirements ["loadpaths"]` instead of calling `Mix.Task.run("app.start")` inside each task.

## Why

These tasks are library-style tasks. They need the package code and dependencies available, but they do not need to start the host application's supervision tree.

Using `app.start` was heavier than necessary and caused `mix spec.*` commands to boot the consumer app even for read-only or file-oriented task flows.

## Impact

- `mix spec.init`, `mix spec.index`, `mix spec.validate`, `mix spec.check`, `mix spec.status`, `mix spec.next`, `mix spec.prime`, and `mix spec.decision.new` now load paths without starting the consumer app
- command verifications still behave the same, because they are executed explicitly by the verifier when requested
- this makes the tasks a better fit for library use inside other Mix projects

## Root Cause

The tasks were using the broadest Mix bootstrap path (`app.start`) even though their current implementations only require compiled code and dependency load paths.

## Validation

- `mix test test/mix/tasks`
- `mix test`
- manual consumer-app check:
  - created a temp supervised Mix app with a sentinel side effect in `Application.start/2`
  - ran `mix spec.init`, `mix spec.validate`, and `mix spec.check`
  - confirmed the tasks succeeded and the sentinel file was never created, so the consumer app did not start
