### PR TITLE
Remove app.start from all spec tasks

### DIFF
--- a/.spec/README.md
+++ b/.spec/README.md
@@ -12,6 +12,7 @@ This project uses its own tooling to specify itself.
 - `AGENTS.md` — local operating guidance for agents working in `.spec/` (authored)
 - `decisions/README.md` — ADR guidance for durable cross-cutting decisions (authored)
 - `decisions/*.md` — accepted or superseded ADRs for the current workspace (authored)
+  - `decisions/specled.decision.no_app_start.md` — spec tasks shall not start the OTP application (accepted)
 - `specs/spec_system.spec.md` — meta-spec for this workspace (authored)
 - `specs/package.spec.md` — package-level contract (authored)
 - `specs/index_state.spec.md` — index building and canonical state rules (authored)

--- a/.spec/decisions/specled.decision.no_app_start.md
+++ b/.spec/decisions/specled.decision.no_app_start.md
@@ -1,0 +1,25 @@
+---
+id: specled.decision.no_app_start
+status: accepted
+date: 2026-04-07
+affects:
+  - specled.mix_tasks
+  - specled.branch_guard
+  - specled.next
+  - specled.prime
+  - specled.status
+---
+
+# Spec Tasks Shall Not Start the OTP Application
+
+## Context
+
+All `mix spec.*` tasks called `Mix.Task.run("app.start")` at the top of their `run/1` function. This caused problems when spec tooling was used inside host applications with slow startup, required environment variables, or side-effectful boot sequences. Spec checks became slow, could incorrectly fail due to missing host configuration, and produced noisy output unrelated to spec validation.
+
+## Decision
+
+Remove `Mix.Task.run("app.start")` from every `mix spec.*` task. Spec tasks perform only file I/O, Git CLI calls, and in-memory parsing — none of which require the host OTP application to be running.
+
+## Consequences
+
+Spec tasks run faster and no longer couple to host application boot. They can be invoked in CI or development without satisfying the host app's runtime prerequisites.

--- a/.spec/specs/branch_guard.spec.md
+++ b/.spec/specs/branch_guard.spec.md
@@ -18,6 +18,7 @@ surface:
 decisions:
   - specled.decision.declarative_current_truth
   - specled.decision.guided_reconciliation_loop
+  - specled.decision.no_app_start
 ```
 
 ## Requirements

--- a/.spec/specs/mix_tasks.spec.md
+++ b/.spec/specs/mix_tasks.spec.md
@@ -29,6 +29,7 @@ decisions:
   - specled.decision.declarative_current_truth
   - specled.decision.local_skill_scaffold
   - specled.decision.guided_reconciliation_loop
+  - specled.decision.no_app_start
 ```
 
 ## Requirements
@@ -78,6 +79,10 @@ decisions:
   statement: mix spec.status shall summarize coverage, verification strength, weak spots, and ADR usage for the current workspace, executing command verifications by default unless explicitly opted out.
   priority: should
   stability: evolving
+- id: specled.tasks.no_app_start
+  statement: No mix spec.* task shall call Mix.Task.run("app.start") or otherwise require the host OTP application to be running, since spec tasks perform only file I/O, Git CLI calls, and in-memory parsing.
+  priority: must
+  stability: stable
 ```
 
 ## Verification
@@ -98,4 +103,5 @@ decisions:
     - specled.tasks.validate_exit_status
     - specled.tasks.check_strict_gate
     - specled.tasks.status_summary
+    - specled.tasks.no_app_start
 ```

--- a/.spec/specs/next.spec.md
+++ b/.spec/specs/next.spec.md
@@ -23,6 +23,7 @@ decisions:
   - specled.decision.declarative_current_truth
   - specled.decision.guided_reconciliation_loop
   - specled.decision.explicit_subject_ownership
+  - specled.decision.no_app_start
 ```
 
 ## Requirements

--- a/.spec/specs/prime.spec.md
+++ b/.spec/specs/prime.spec.md
@@ -18,6 +18,7 @@ surface:
 decisions:
   - specled.decision.declarative_current_truth
   - specled.decision.guided_reconciliation_loop
+  - specled.decision.no_app_start
 ```
 
 ## Requirements

--- a/.spec/specs/status.spec.md
+++ b/.spec/specs/status.spec.md
@@ -19,6 +19,7 @@ decisions:
   - specled.decision.declarative_current_truth
   - specled.decision.explicit_subject_ownership
   - specled.decision.guided_reconciliation_loop
+  - specled.decision.no_app_start
 ```
 
 ## Requirements

--- a/.spec/state.json
+++ b/.spec/state.json
@@ -71,6 +71,20 @@
         "id": "specled.decision.local_skill_scaffold",
         "status": "accepted",
         "title": "Local Skill Scaffold Supports Repo Usage"
+      },
+      {
+        "affects": [
+          "specled.mix_tasks",
+          "specled.branch_guard",
+          "specled.next",
+          "specled.prime",
+          "specled.status"
+        ],
+        "date": "2026-04-07",
+        "file": ".spec/decisions/specled.decision.no_app_start.md",
+        "id": "specled.decision.no_app_start",
+        "status": "accepted",
+        "title": "Spec Tasks Shall Not Start the OTP Application"
       }
     ]
   },
@@ -268,6 +282,14 @@
         "priority": "should",
         "stability": "evolving",
         "statement": "mix spec.next shall provide a read-only guided reconciliation step that points at the next subject, proof, or ADR update for the current Git change set and tell the maintainer when the branch is ready for the full local check.",
+        "subject_id": "specled.mix_tasks"
+      },
+      {
+        "file": ".spec/specs/mix_tasks.spec.md",
+        "id": "specled.tasks.no_app_start",
+        "priority": "must",
+        "stability": "stable",
+        "statement": "No mix spec.* task shall call Mix.Task.run(\"app.start\") or otherwise require the host OTP application to be running, since spec tasks perform only file I/O, Git CLI calls, and in-memory parsing.",
         "subject_id": "specled.mix_tasks"
       },
       {
@@ -623,7 +645,8 @@
         "meta": {
           "decisions": [
             "specled.decision.declarative_current_truth",
-            "specled.decision.guided_reconciliation_loop"
+            "specled.decision.guided_reconciliation_loop",
+            "specled.decision.no_app_start"
           ],
           "id": "specled.branch_guard",
           "kind": "workflow",
@@ -685,7 +708,8 @@
           "decisions": [
             "specled.decision.declarative_current_truth",
             "specled.decision.local_skill_scaffold",
-            "specled.decision.guided_reconciliation_loop"
+            "specled.decision.guided_reconciliation_loop",
+            "specled.decision.no_app_start"
           ],
           "id": "specled.mix_tasks",
           "kind": "workflow",
@@ -717,7 +741,8 @@
           "decisions": [
             "specled.decision.declarative_current_truth",
             "specled.decision.guided_reconciliation_loop",
-            "specled.decision.explicit_subject_ownership"
+            "specled.decision.explicit_subject_ownership",
+            "specled.decision.no_app_start"
           ],
           "id": "specled.next",
           "kind": "workflow",
@@ -782,7 +807,8 @@
         "meta": {
           "decisions": [
             "specled.decision.declarative_current_truth",
-            "specled.decision.guided_reconciliation_loop"
+            "specled.decision.guided_reconciliation_loop",
+            "specled.decision.no_app_start"
           ],
           "id": "specled.prime",
           "kind": "workflow",
@@ -829,7 +855,8 @@
           "decisions": [
             "specled.decision.declarative_current_truth",
             "specled.decision.explicit_subject_ownership",
-            "specled.decision.guided_reconciliation_loop"
+            "specled.decision.guided_reconciliation_loop",
+            "specled.decision.no_app_start"
           ],
           "id": "specled.status",
           "kind": "workflow",
@@ -978,7 +1005,8 @@
           "specled.tasks.validate_findings",
           "specled.tasks.validate_exit_status",
           "specled.tasks.check_strict_gate",
-          "specled.tasks.status_summary"
+          "specled.tasks.status_summary",
+          "specled.tasks.no_app_start"
         ],
         "execute": true,
         "file": ".spec/specs/mix_tasks.spec.md",
@@ -1086,10 +1114,10 @@
   "specification_version": "1.0",
   "summary": {
     "decision_parse_errors": 0,
-    "decisions": 5,
+    "decisions": 6,
     "exceptions": 0,
     "findings": 0,
-    "requirements": 53,
+    "requirements": 54,
     "scenarios": 5,
     "subjects": 12,
     "verifications": 18
@@ -1384,6 +1412,17 @@
       },
       {
         "cover_id": "specled.tasks.next_guidance",
+        "file": ".spec/specs/mix_tasks.spec.md",
+        "kind": "command",
+        "meets_minimum": true,
+        "required_strength": "claimed",
+        "strength": "executed",
+        "subject_id": "specled.mix_tasks",
+        "target": "mix test test/mix/tasks/spec_tasks_test.exs test/mix/tasks/spec_status_task_test.exs test/mix/tasks/spec_next_task_test.exs test/mix/tasks/spec_prime_task_test.exs",
+        "verification_index": 0
+      },
+      {
+        "cover_id": "specled.tasks.no_app_start",
         "file": ".spec/specs/mix_tasks.spec.md",
         "kind": "command",
         "meets_minimum": true,
@@ -1717,13 +1756,13 @@
     "default_minimum_strength": "claimed",
     "strength_summary": {
       "claimed": 2,
-      "executed": 46,
+      "executed": 47,
       "linked": 8
     },
     "threshold_failures": 0
   },
   "workspace": {
-    "decision_count": 5,
+    "decision_count": 6,
     "spec_count": 12
   }
 }

--- a/lib/mix/tasks/spec.check.ex
+++ b/lib/mix/tasks/spec.check.ex
@@ -19,8 +19,6 @@ defmodule Mix.Tasks.Spec.Check do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.decision.new.ex
+++ b/lib/mix/tasks/spec.decision.new.ex
@@ -6,8 +6,6 @@ defmodule Mix.Tasks.Spec.Decision.New do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.index.ex
+++ b/lib/mix/tasks/spec.index.ex
@@ -5,8 +5,6 @@ defmodule Mix.Tasks.Spec.Index do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.init.ex
+++ b/lib/mix/tasks/spec.init.ex
@@ -17,8 +17,6 @@ defmodule Mix.Tasks.Spec.Init do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(args,
         strict: [root: :string, force: :boolean],

--- a/lib/mix/tasks/spec.next.ex
+++ b/lib/mix/tasks/spec.next.ex
@@ -5,8 +5,6 @@ defmodule Mix.Tasks.Spec.Next do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.prime.ex
+++ b/lib/mix/tasks/spec.prime.ex
@@ -15,8 +15,6 @@ defmodule Mix.Tasks.Spec.Prime do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.status.ex
+++ b/lib/mix/tasks/spec.status.ex
@@ -14,8 +14,6 @@ defmodule Mix.Tasks.Spec.Status do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,

--- a/lib/mix/tasks/spec.validate.ex
+++ b/lib/mix/tasks/spec.validate.ex
@@ -16,8 +16,6 @@ defmodule Mix.Tasks.Spec.Validate do
 
   @impl true
   def run(args) do
-    Mix.Task.run("app.start")
-
     {opts, rest, invalid} =
       OptionParser.parse(
         args,


### PR DESCRIPTION
Spec tasks only do file I/O, Git CLI calls, and in-memory parsing — they never need the host OTP application running. Calling app.start caused slow runs, false failures from missing env vars, and noisy output in host applications with heavyweight boot sequences.

ADR: specled.decision.no_app_start