### PR TITLE
Mark Spec Led Development as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SpecLedEx
 
+> **Maintenance status**
+>
+> Spec Led Development is no longer maintained. This repository remains public as a reference. No new features, bug fixes, or support are planned.
+
 Local helper package for Spec Led Development repositories.
 
 The commands make the most sense when you group them by job instead of reading


### PR DESCRIPTION
## Summary

- add a prominent maintenance-status notice to the repository README
- state that the repository remains public as a reference
- set expectations that no new features, bug fixes, or support are planned

## Why

The public repository currently presents Spec Led Development without an explicit maintenance status. This update makes the project state clear at the first entry point.

## Impact

Documentation only. Runtime behavior is unchanged.

## Validation

- `git diff --check`
